### PR TITLE
Add MI 4.5.0 to products list

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -18,7 +18,8 @@
         {
             "tagName": "v2.0.0",
             "products": [
-                "MI 4.4.0"
+                "MI 4.4.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {
@@ -279,7 +280,8 @@
         {
             "tagName": "v2.0.0",
             "products": [
-                "MI 4.4.0"
+                "MI 4.4.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {
@@ -315,7 +317,8 @@
                 "MI 4.3.0",
                 "MI 4.2.0",
                 "MI 4.1.0",
-                "MI 4.0.0"
+                "MI 4.0.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {


### PR DESCRIPTION
This PR adds MI 4.5.0 to the products list for releases that already contain MI 4.4.0, ensuring compatibility with the new Micro Integrator version.